### PR TITLE
fix: use fresh context object per request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "dag.w3s.link",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@web3-storage/gateway-lib": "^3.2.3"
+        "@web3-storage/gateway-lib": "^3.2.4"
       },
       "devDependencies": {
         "ava": "^5.2.0",
@@ -2749,9 +2749,9 @@
       "dev": true
     },
     "node_modules/@web3-storage/gateway-lib": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.2.3.tgz",
-      "integrity": "sha512-O5d4uVATWemM4356LX1cO2RJVLOcKc2nl4Vfd/765oi25fiI5liDTUm9zGKP3mya4fpbsWRI+ap2Pt+W6mJGdQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.2.4.tgz",
+      "integrity": "sha512-bxRy2tt5wqtPRS/nlHqu8OppAPm7klrQp441UVsA+dKHL4W/ElFNQNU/ux8UHe9+ww1UzV0d4EXRJ+CDSpY/BQ==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Alan Shaw",
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
-    "@web3-storage/gateway-lib": "^3.2.3"
+    "@web3-storage/gateway-lib": "^3.2.4"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* eslint-env worker */
 import {
+  withContext,
   withErrorHandler,
   withHttpGet,
   withParsedIpfsUrl,
@@ -20,6 +21,7 @@ export default {
     const middleware = composeMiddleware(
       withErrorHandler,
       withHttpGet,
+      withContext,
       withParsedIpfsUrl,
       withDenylist,
       withCdnCache


### PR DESCRIPTION
FML I forgot that `dag.w3s.link` also mutates the context - it extracts CID/path from the URL to query the denylist.

Propagating the fix from https://github.com/web3-storage/freeway/pull/60 here as well.